### PR TITLE
Add termination condition to demo

### DIFF
--- a/src/demo.py
+++ b/src/demo.py
@@ -36,54 +36,62 @@ def test_camera(mtcnn,index = 0):
 
     while(1):
         success, frame = cam.read()
-        image = frame
+        if success:
+            image = frame
 
-        img_size = np.asarray(image.shape)[0:2]
+            img_size = np.asarray(image.shape)[0:2]
+
+            bounding_boxes, scores, landmarks = mtcnn.detect(image)
+
+            nrof_faces = bounding_boxes.shape[0]
+            if nrof_faces > 0:
+                for det, pts in zip(bounding_boxes, landmarks):
+
+                    det = det.astype('int32')
+                    #print("face confidence: %2.3f" % confidence)
+                    det = np.squeeze(det)
+                    y1 = int(np.maximum(det[0], 0))
+                    x1 = int(np.maximum(det[1], 0))
+                    y2 = int(np.minimum(det[2], img_size[1]-1))
+                    x2 = int(np.minimum(det[3], img_size[0]-1))
+
+                    w = x2-x1
+                    h = y2-y1
+                    _r = int(max(w,h)*0.6)
+                    cx,cy = (x1+x2)//2, (y1+y2)//2
+
+                    x1 = cx - _r 
+                    y1 = cy - _r 
+
+                    x1 = int(max(x1,0))
+                    y1 = int(max(y1,0))
+
+                    x2 = cx + _r 
+                    y2 = cy + _r 
+
+                    h,w,c =frame.shape
+                    x2 = int(min(x2 ,w-2))
+                    y2 = int(min(y2, h-2))
+
+                    _frame = frame[y1:y2 , x1:x2]
+                    score = test_one(_frame)
+
+                    print(score)
+                    if score > 0.95:
+                        cv2.rectangle(frame, (x1,y1) ,(x2,y2) , (0,255,0)  ,2)
+                    else:
+                        cv2.rectangle(frame, (x1,y1) ,(x2,y2) , (255,0,0)  ,2)
+
+            cv2.imshow("image", image)
+            if cv2.waitKey(1) & 0XFF == ord('q'):
+                cv2.destroyAllWindows()
+                cam.release()
+                break                
         
-        bounding_boxes, scores, landmarks = mtcnn.detect(image)
-        
-        nrof_faces = bounding_boxes.shape[0]
-        if nrof_faces > 0:
-            for det, pts in zip(bounding_boxes, landmarks):
-
-                det = det.astype('int32')
-                #print("face confidence: %2.3f" % confidence)
-                det = np.squeeze(det)
-                y1 = int(np.maximum(det[0], 0))
-                x1 = int(np.maximum(det[1], 0))
-                y2 = int(np.minimum(det[2], img_size[1]-1))
-                x2 = int(np.minimum(det[3], img_size[0]-1))
-
-                w = x2-x1
-                h = y2-y1
-                _r = int(max(w,h)*0.6)
-                cx,cy = (x1+x2)//2, (y1+y2)//2
-
-                x1 = cx - _r 
-                y1 = cy - _r 
-
-                x1 = int(max(x1,0))
-                y1 = int(max(y1,0))
-
-                x2 = cx + _r 
-                y2 = cy + _r 
-
-                h,w,c =frame.shape
-                x2 = int(min(x2 ,w-2))
-                y2 = int(min(y2, h-2))
-
-                _frame = frame[y1:y2 , x1:x2]
-                score = test_one(_frame)
-
-                print(score)
-                if score > 0.95:
-                    cv2.rectangle(frame, (x1,y1) ,(x2,y2) , (0,255,0)  ,2)
-                else:
-                    cv2.rectangle(frame, (x1,y1) ,(x2,y2) , (255,0,0)  ,2)
-
-        cv2.imshow("image", image)
-        cv2.waitKey(1)
-       
+        else:
+            cv2.destroyAllWindows()
+            cam.release()
+            break
 
 if __name__ == '__main__':
     


### PR DESCRIPTION
Right now if the end of video file is reached the interpreter crashes. This will not happen if the validity of the grabbed frame is checked and the cap is released in case of and error.